### PR TITLE
Allow to query non-existant sections

### DIFF
--- a/include/boost/dll/detail/pe_info.hpp
+++ b/include/boost/dll/detail/pe_info.hpp
@@ -320,8 +320,10 @@ public:
                     section_end_addr = section_begin_addr + image_section_header.SizeOfRawData;
                 }
             }
-            BOOST_ASSERT(section_begin_addr);
-            BOOST_ASSERT(section_end_addr);
+            
+            // returning empty result if section was not found
+            if(section_begin_addr == 0 || section_end_addr == 0)
+                return ret;
         }
 
         const exports_t exprt = exports(h);

--- a/test/library_info_test.cpp
+++ b/test/library_info_test.cpp
@@ -44,6 +44,8 @@ int main(int argc, char* argv[])
     BOOST_TEST(std::find(symb.begin(), symb.end(), "say_hello") == symb.end());
     BOOST_TEST(lib_info.symbols(std::string("boostdll")) == symb);
 
+    empty = lib_info.symbols("empty");
+    BOOST_TEST(empty.empty() == true);
 
     // Self testing
     std::cout << "Self: " << argv[0];


### PR DESCRIPTION
Sometimes it is convenient to query a library for a specific section and expect an empty result if the section does not exists. This was not possible because library_info ASSERTed the section adresses thus crashing the Application if a section was not found.
Fixed this by checking section begin and end and returning an emtpy vector of string if the section was not found.

It seems only affect pe_info.hpp, the other implementations seem to allow empty sections (or handle them differently altogether)