### PR TITLE
Update refcounting_plugin.hpp

### DIFF
--- a/example/tutorial8/refcounting_plugin.hpp
+++ b/example/tutorial8/refcounting_plugin.hpp
@@ -5,6 +5,9 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// MinGW related workaround
+#define BOOST_DLL_FORCE_ALIAS_INSTANTIATION
+
 //[plugcpp_my_plugin_refcounting_hpp
 #include "refcounting_api.hpp"
 #include <boost/dll/alias.hpp> // for BOOST_DLL_ALIAS


### PR DESCRIPTION
Without BOOST_DLL_FORCE_ALIAS_INSTANTIATION it is not working under Windows with MinGW. Tested with TDM-GCC 492-x64