### PR TITLE
add cmake option BOOST_DLL_USE_STD_FS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project(boost_dll VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 add_library(boost_dll INTERFACE)
 add_library(Boost::dll ALIAS boost_dll)
 
+option(BOOST_DLL_USE_STD_FS "Use std::filesystem instead of Boost.Filesystem" OFF)
+
 target_include_directories(boost_dll INTERFACE include)
 
 target_link_libraries(boost_dll
@@ -18,7 +20,6 @@ target_link_libraries(boost_dll
     Boost::assert
     Boost::config
     Boost::core
-    Boost::filesystem
     Boost::predef
     Boost::system
     Boost::throw_exception
@@ -27,8 +28,14 @@ target_link_libraries(boost_dll
     ${CMAKE_DL_LIBS}
 )
 
-if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+if (BOOST_DLL_USE_STD_FS)
+  target_compile_definitions(boost_dll INTERFACE BOOST_DLL_USE_STD_FS)
+else()
+  target_link_libraries(boost_dll INTERFACE Boost::filesystem)
+endif()
 
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+    
   add_subdirectory(test)
 
 endif()


### PR DESCRIPTION
add a cmake option, so when `BOOST_DLL_USE_STD_FS` is on we don't need to link Boost.Filesystem