### PR TITLE
Fix compiling & exporting on Cygwin

### DIFF
--- a/include/boost/dll/alias.hpp
+++ b/include/boost/dll/alias.hpp
@@ -180,8 +180,30 @@ namespace boost { namespace dll {
     namespace _autoaliases {                                                                    \
         extern "C" BOOST_SYMBOL_EXPORT const void *FunctionOrVar;                               \
     } /* namespace _autoaliases */                                                              \
-    /**/
-#else    
+/**/
+#elif BOOST_OS_CYGWIN
+#define BOOST_DLL_ALIAS_SECTIONED(FunctionOrVar, AliasName, SectionName)                        \
+    namespace _autoaliases {                                                                    \
+        extern "C" BOOST_SYMBOL_EXPORT const void *AliasName;                                   \
+        BOOST_DLL_SECTION(SectionName, read)                                                    \
+        const void * AliasName = reinterpret_cast<const void*>(reinterpret_cast<intptr_t>(      \
+            &FunctionOrVar                                                                      \
+        ));                                                                                     \
+    } /* namespace _autoaliases */                                                              \
+/**/
+
+#define BOOST_DLL_AUTO_ALIAS(FunctionOrVar)                                                     \
+    namespace _autoaliases {                                                                    \
+        const void * dummy_ ## FunctionOrVar                                                    \
+            = reinterpret_cast<const void*>(reinterpret_cast<intptr_t>(                         \
+                &FunctionOrVar                                                                  \
+            ));                                                                                 \
+        extern "C" BOOST_SYMBOL_EXPORT const void *FunctionOrVar;                               \
+        BOOST_DLL_SECTION(boostdll, read)                                                       \
+        const void * FunctionOrVar = dummy_ ## FunctionOrVar;                                   \
+    } /* namespace _autoaliases */                                                              \
+/**/
+#else
 // Note: we can not use `aggressive_ptr_cast` here, because in that case GCC applies
 // different permissions to the section and it causes Segmentation fault.
 // Note: we can not use `std::addressof()` here, because in that case GCC 

--- a/include/boost/dll/detail/posix/path_from_handle.hpp
+++ b/include/boost/dll/detail/posix/path_from_handle.hpp
@@ -104,6 +104,15 @@ namespace boost { namespace dll { namespace detail {
 #if BOOST_OS_QNX
 // QNX's copy of <elf.h> and <link.h> reside in sys folder
 #   include <sys/link.h>
+#elif BOOST_OS_CYGWIN
+// Cygwin returns the opaque pointer-sized handle of type `HMODULE` on the invoke of `dlopen`,
+// which cannot be interpreted. As GCC on Cygwin always links to KERNEL32.DLL, we can use the
+// standard Win32 API `GetModuleFileNameW` to implement `path_from_handle`
+//
+// Introduce the Win32 API `GetModuleFileNameW` here
+extern "C" void GetModuleFileNameW(void*, wchar_t*, unsigned long long);
+// Introduce the Win32 API `GetLastError` here
+extern "C" unsigned long long GetLastError();
 #else
 #   include <link.h>    // struct link_map
 #endif
@@ -129,9 +138,29 @@ namespace boost { namespace dll { namespace detail {
         // Unfortunately we can not use `dlinfo(handle, RTLD_DI_LINKMAP, &link_map) < 0`
         // because it is not supported on MacOS X 10.3, NetBSD 3.0, OpenBSD 3.8, AIX 5.1,
         // HP-UX 11, IRIX 6.5, OSF/1 5.1, Cygwin, mingw, Interix 3.5, BeOS.
-        // Fortunately investigating the sources of open source projects brought the understanding, that
+        // Fortunately, investigating the sources of open source projects brought the understanding, that
         // `handle` is just a `struct link_map*` that contains full library name.
 
+#if BOOST_OS_CYGWIN
+        // Cygwin doesn't have <link.h> header
+        unsigned long long DEFAULT_BUFFER_SIZE = 4096;
+        std::vector<wchar_t> buffer(DEFAULT_BUFFER_SIZE);
+        do
+        {
+            buffer.resize(DEFAULT_BUFFER_SIZE);
+            GetModuleFileNameW(handle, buffer.data(), buffer.size());
+            DEFAULT_BUFFER_SIZE *= 2;
+        } while (GetLastError() == 122 /* ERROR_INSUFFICIENT_BUFFER */);
+        if (GetLastError() == 0)
+        {
+            return boost::filesystem::path(buffer.data());
+        } else
+        {
+            boost::dll::detail::reset_dlerror();
+            ec = std::make_error_code(std::errc::bad_file_descriptor);
+            return boost::filesystem::path();
+        }
+#else
         const struct link_map* link_map = 0;
 #if BOOST_OS_BSD_FREE
         // FreeBSD has it's own logic http://code.metager.de/source/xref/freebsd/libexec/rtld-elf/rtld.c
@@ -156,6 +185,7 @@ namespace boost { namespace dll { namespace detail {
         }
 
         return boost::dll::fs::path(link_map->l_name);
+#endif
     }
 
 }}} // namespace boost::dll::detail

--- a/include/boost/dll/detail/posix/path_from_handle.hpp
+++ b/include/boost/dll/detail/posix/path_from_handle.hpp
@@ -143,13 +143,13 @@ namespace boost { namespace dll { namespace detail {
 
 #if BOOST_OS_CYGWIN
         // Cygwin doesn't have <link.h> header
-        unsigned long long DEFAULT_BUFFER_SIZE = 4096;
-        std::vector<wchar_t> buffer(DEFAULT_BUFFER_SIZE);
+        unsigned long long buffer_size = 4096;
+        std::vector<wchar_t> buffer;
         do
         {
-            buffer.resize(DEFAULT_BUFFER_SIZE);
+            buffer.resize(buffer_size);
             GetModuleFileNameW(handle, buffer.data(), buffer.size());
-            DEFAULT_BUFFER_SIZE *= 2;
+            buffer_size *= 2;
         } while (GetLastError() == 122 /* ERROR_INSUFFICIENT_BUFFER */);
         if (GetLastError() == 0)
         {

--- a/include/boost/dll/detail/posix/shared_library_impl.hpp
+++ b/include/boost/dll/detail/posix/shared_library_impl.hpp
@@ -20,7 +20,7 @@
 
 #include <dlfcn.h>
 #include <cstring> // strncmp
-#if !BOOST_OS_MACOS && !BOOST_OS_IOS && !BOOST_OS_QNX
+#if !BOOST_OS_MACOS && !BOOST_OS_IOS && !BOOST_OS_QNX && !BOOST_OS_CYGWIN
 #   include <link.h>
 #elif BOOST_OS_QNX
 // QNX's copy of <elf.h> and <link.h> reside in sys folder

--- a/include/boost/dll/runtime_symbol_info.hpp
+++ b/include/boost/dll/runtime_symbol_info.hpp
@@ -17,6 +17,20 @@
 #   include <boost/winapi/dll.hpp>
 #   include <boost/dll/detail/windows/path_from_handle.hpp>
 #else
+#if BOOST_OS_CYGWIN
+// `Dl_info` & `dladdr` is hidden by `__GNU_VISIBLE`
+typedef struct Dl_info Dl_info;
+
+struct Dl_info
+{
+    char        dli_fname[PATH_MAX];  /* Filename of defining object */
+    void       *dli_fbase;            /* Load address of that object */
+    const char *dli_sname;            /* Name of nearest lower symbol */
+    void       *dli_saddr;            /* Exact value of nearest symbol */
+};
+
+extern "C" int dladdr (const void *addr, Dl_info *info);
+#endif
 #   include <dlfcn.h>
 #   include <boost/dll/detail/posix/program_location_impl.hpp>
 #endif


### PR DESCRIPTION
This fixes [issue 17](https://github.com/boostorg/dll/issues/17)
- Use native Win32 API to get the path of the dynamic module (By revealing Cygwin's implementation of `dlopen`)
- Fix missing of export when using `BOOST_DLL_ALIAS_SECTIONED` caused by `__attribute__((weak))`